### PR TITLE
feat(src): add planning component

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "axios": "^1.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "lucide-react": "^0.510.0",
     "next": "15.3.2",
     "react": "^19.0.0",
@@ -43,5 +44,6 @@
     "tailwindcss": "^4",
     "tw-animate-css": "^1.2.9",
     "typescript": "^5"
-  }
+  },
+  "packageManager": "pnpm@9.12.3+sha512.cce0f9de9c5a7c95bef944169cc5dfe8741abfb145078c0d508b868056848a87c81e626246cb60967cbd7fd29a6c062ef73ff840d96b3c86c40ac92cf4a813ee"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       lucide-react:
         specifier: ^0.510.0
         version: 0.510.0(react@19.1.0)
@@ -1054,6 +1057,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -3597,6 +3603,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns@4.1.0: {}
 
   debug@3.2.7:
     dependencies:

--- a/src/app/planning/page.tsx
+++ b/src/app/planning/page.tsx
@@ -1,0 +1,9 @@
+import Planning from "@/components/Planning";
+
+export default function PlanningPage() {
+  return (
+    <div className="min-h-screen flex flex-col bg-white">
+      <Planning />
+    </div>
+  );
+}

--- a/src/components/Planning.tsx
+++ b/src/components/Planning.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import * as React from "react";
+import { Calendar } from "@/components/ui/calendar";
+
+export default function Planning() {
+  const [date, setDate] = React.useState<Date | null>(new Date());
+
+  const fetchMockData = () => ({
+    users: [
+      { id: 1, role: "speaker" },
+      { id: 2, role: "organizer" },
+      { id: 3, role: "public" },
+    ],
+    talks: [
+      {
+        id: 1,
+        title: "Talk 1",
+        description: "Description du talk 1",
+        duration: 60,
+        level: "beginner",
+        status: "scheduled",
+        speaker_id: 1,
+        timeslot: { start: new Date(2025, 4, 10, 10, 0), end: new Date(2025, 4, 10, 11, 0) },
+        room_id: 201,
+      },
+      {
+        id: 2,
+        title: "Talk 2",
+        description: "Description du talk 2",
+        duration: 90,
+        level: "intermediate",
+        status: "scheduled",
+        speaker_id: 1,
+        timeslot: { start: new Date(2025, 4, 18, 14, 0), end: new Date(2025, 4, 18, 15, 30) },
+        room_id: 202,
+      },
+      {
+        id: 3,
+        title: "Talk 3",
+        description: "Description du talk 3",
+        duration: 45,
+        level: "advanced",
+        status: "pending",
+        speaker_id: 1,
+        timeslot: { start: new Date(2025, 4, 20, 9, 0), end: new Date(2025, 4, 20, 9, 45) },
+        room_id: 203,
+      },
+      {
+        id: 4,
+        title: "Talk 4",
+        description: "Description du talk 4",
+        duration: 90,
+        level: "intermediate",
+        status: "scheduled",
+        speaker_id: 2,
+        timeslot: { start: new Date(2025, 4, 18, 14, 0), end: new Date(2025, 4, 18, 15, 30) },
+        room_id: 202,
+      },
+      {
+        id: 5,
+        title: "Talk 5",
+        description: "Description du talk 5",
+        duration: 45,
+        level: "advanced",
+        status: "pending",
+        speaker_id: 3,
+        timeslot: { start: new Date(2025, 4, 20, 9, 0), end: new Date(2025, 4, 20, 9, 45) },
+        room_id: 203,
+      },
+    ],
+  });
+
+  const { users, talks: talkData } = fetchMockData();
+  const currentUser = users[0];
+
+  const talks = React.useMemo(() => {
+    const today = new Date();
+
+    return talkData.map((talk) => ({
+      date: talk.timeslot.start,
+      isPastWithTalk: talk.timeslot.start < today,
+      isWithTalk: talk.status === "scheduled",
+      isOrganizedTalk: currentUser.role === "organizer",
+      isSpeakerTalk: currentUser.role === "speaker" && talk.speaker_id === currentUser.id,
+      isPublicTalk: currentUser.role === "public",
+      title: talk.title,
+    }));
+  }, [talkData, currentUser]);
+
+  return (
+    <div className="flex h-screen">
+      <aside className="w-1/5 bg-gray-100 p-4">
+        <h2 className="text-lg font-semibold mb-4">Date du jour</h2>
+        <ul className="space-y-2">
+          <li className="text-sm text-gray-700 hover:text-gray-900 cursor-pointer">
+            Prochain talk
+          </li>
+          <li className="text-sm text-gray-700 hover:text-gray-900 cursor-pointer">Bouton 1</li>
+          <li className="text-sm text-gray-700 hover:text-gray-900 cursor-pointer">Bouton 2</li>
+        </ul>
+      </aside>
+
+      <main className="w-4/5 p-6 flex flex-col">
+        <Calendar
+          selectedDate={date}
+          onDateChange={setDate}
+          className="w-full h-full"
+          talks={talks}
+          userRole={currentUser.role}
+        />
+      </main>
+    </div>
+  );
+}

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import * as React from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { format, isSameDay } from "date-fns";
+import { fr } from "date-fns/locale";
+import { cn } from "@/lib/utils";
+import { useCalendarLogic } from "@/hooks/Calendar";
+
+type Talk = {
+  date: Date;
+  isPastWithTalk: boolean;
+  isWithTalk: boolean;
+  isOrganizedTalk: boolean;
+  isSpeakerTalk: boolean;
+  isPublicTalk: boolean;
+  title?: string;
+};
+
+export function Calendar({
+  selectedDate,
+  onDateChange,
+  className,
+  talks = [],
+  userRole = "public",
+}: {
+  selectedDate: Date | null;
+  onDateChange: (date: Date) => void;
+  className?: string;
+  talks?: Talk[];
+  userRole?: string;
+}) {
+  const {
+    currentMonth,
+    handleMonthChange,
+    hoveredDay,
+    setHoveredDay,
+    daysInMonth,
+    getDayStyle,
+    getTalksForDay,
+  } = useCalendarLogic(talks, userRole);
+
+  return (
+    <div className={cn("p-4", className)}>
+      <div className="flex items-center justify-between mb-4">
+        <button
+          onClick={() => handleMonthChange("previous")}
+          className="p-2 rounded hover:bg-gray-200"
+        >
+          <ChevronLeft className="h-5 w-5" />
+        </button>
+        <h2 className="text-lg font-semibold">
+          {format(currentMonth, "MMMM yyyy", { locale: fr })}
+        </h2>
+        <button
+          onClick={() => handleMonthChange("next")}
+          className="p-2 rounded hover:bg-gray-200"
+        >
+          <ChevronRight className="h-5 w-5" />
+        </button>
+      </div>
+
+      <div className="grid grid-cols-7 gap-2 relative">
+        {["Lun", "Mar", "Mer", "Jeu", "Ven", "Sam", "Dim"].map((day) => (
+          <div key={day} className="text-center font-medium text-gray-600">
+            {day}
+          </div>
+        ))}
+
+        {daysInMonth.map((day) => {
+          const dayTalks = getTalksForDay(day);
+
+          return (
+            <div
+              key={day.toISOString()}
+              className="relative"
+            >
+              <button
+                onClick={() => onDateChange(day)}
+                className={cn(
+                  "p-2 rounded text-center w-full",
+                  selectedDate?.toDateString() === day.toDateString()
+                    ? "ring-2 ring-blue-500"
+                    : "",
+                  getDayStyle(day)
+                )}
+              >
+                {day.getDate()}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/Calendar.ts
+++ b/src/hooks/Calendar.ts
@@ -1,0 +1,74 @@
+import { useMemo } from "react";
+import { isSameDay } from "date-fns";
+import { useCalendarStore } from "@/stores/useCalendarStore";
+
+type Talk = {
+  date: Date;
+  isPastWithTalk: boolean;
+  isWithTalk: boolean;
+  isOrganizedTalk: boolean;
+  isSpeakerTalk: boolean;
+  isPublicTalk: boolean;
+  title?: string;
+};
+
+export function useCalendarLogic(talks: Talk[], userRole: string) {
+  const {
+    currentMonth,
+    setCurrentMonth,
+    hoveredDay,
+    setHoveredDay,
+  } = useCalendarStore();
+
+  const filteredTalks = useMemo(
+    () =>
+      talks.filter((talk) => {
+        if (talk.isPastWithTalk || talk.isWithTalk) return true;
+        if (userRole === "organizer" && talk.isOrganizedTalk) return true;
+        if (userRole === "speaker" && talk.isSpeakerTalk) return true;
+        if (userRole === "public" && talk.isPublicTalk) return true;
+        return false;
+      }),
+    [talks, userRole]
+  );
+
+  const daysInMonth = useMemo(
+    () =>
+      Array.from(
+        {
+          length: new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0).getDate(),
+        },
+        (_, i) => new Date(currentMonth.getFullYear(), currentMonth.getMonth(), i + 1)
+      ),
+    [currentMonth]
+  );
+
+  const handleMonthChange = (direction: "previous" | "next") => {
+    setCurrentMonth(
+      new Date(currentMonth.setMonth(currentMonth.getMonth() + (direction === "next" ? 1 : -1)))
+    );
+  };
+
+  const getDayStyle = (day: Date) => {
+    const talk = filteredTalks.find((e) => isSameDay(e.date, day));
+    if (talk?.isPastWithTalk) return "bg-blue-100 text-black hover:bg-green-100";
+    if (talk?.isWithTalk) return "bg-blue-800 text-white hover:bg-green-500";
+    if (talk?.isOrganizedTalk) return "bg-yellow-500 text-white hover:bg-green-500";
+    if (talk?.isSpeakerTalk) return "bg-green-800 text-white hover:bg-green-500";
+    if (talk?.isPublicTalk) return "bg-green-800 text-white hover:bg-green-500";
+    return "border-black border hover:bg-green-500 hover:border-green-500";
+  };
+
+  const getTalksForDay = (day: Date) =>
+    filteredTalks.filter((e) => isSameDay(e.date, day));
+
+  return {
+    currentMonth,
+    setHoveredDay,
+    hoveredDay,
+    handleMonthChange,
+    daysInMonth,
+    getDayStyle,
+    getTalksForDay,
+  };
+}

--- a/src/stores/useCalendarStore.ts
+++ b/src/stores/useCalendarStore.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+type CalendarState = {
+  currentMonth: Date;
+  setCurrentMonth: (date: Date) => void;
+  hoveredDay: Date | null;
+  setHoveredDay: (date: Date | null) => void;
+};
+
+export const useCalendarStore = create<CalendarState>((set) => ({
+  currentMonth: new Date(),
+  setCurrentMonth: (date) => set({ currentMonth: date }),
+  hoveredDay: null,
+  setHoveredDay: (date) => set({ hoveredDay: date }),
+}));


### PR DESCRIPTION
Ajout du composant Planning interactif permettant de naviguer entre les mois et de sélectionner une date:
- affichage du calendrier avec les jours de la semaine et les jours du mois courant.
- gestion du changement de mois via des boutons “précédent” et “suivant”.
- mise en place d’une logique métier via un hook personnalisé pour gérer l’état du mois courant, les jours du mois, et le survol des jours.
- prise en compte des talks associés à chaque jour, filtrés selon le rôle utilisateur.
- séparation claire entre la logique métier et la couche UI pour une meilleure maintenabilité.

