### PR TITLE
Feat/tooltip

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -5,7 +5,9 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { format, isSameDay } from "date-fns";
 import { fr } from "date-fns/locale";
 import { cn } from "@/lib/utils";
+import { Tooltip } from "@/components/ui/tooltip";
 import { useCalendarLogic } from "@/hooks/Calendar";
+import { useTooltipStore } from "@/stores/useTooltipStore";
 
 type Talk = {
   date: Date;
@@ -40,6 +42,8 @@ export function Calendar({
     getTalksForDay,
   } = useCalendarLogic(talks, userRole);
 
+  const setTooltipData = useTooltipStore((state) => state.setTooltipData);
+
   return (
     <div className={cn("p-4", className)}>
       <div className="flex items-center justify-between mb-4">
@@ -73,6 +77,11 @@ export function Calendar({
           return (
             <div
               key={day.toISOString()}
+              onMouseEnter={() => {
+                setHoveredDay(day);
+                setTooltipData(dayTalks, { top: 40, left: 0 }, userRole);
+              }}
+              onMouseLeave={() => setHoveredDay(null)}
               className="relative"
             >
               <button
@@ -87,6 +96,7 @@ export function Calendar({
               >
                 {day.getDate()}
               </button>
+              {hoveredDay && isSameDay(hoveredDay, day) && <Tooltip />}
             </div>
           );
         })}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as React from "react";
+import { useTooltipStore } from "@/stores/useTooltipStore";
+import { useTooltipLogic } from "@/hooks/Tooltip";
+
+export function Tooltip() {
+  const { talks, position } = useTooltipStore();
+  const { getTooltipContent } = useTooltipLogic();
+
+  return (
+    <div
+      className="absolute bg-white border border-gray-300 shadow-lg p-2 rounded z-10"
+      style={{ top: position?.top || 0, left: position?.left || 0 }}
+    >
+      {talks.length > 0 ? (
+        <>
+          <h3 className="font-semibold text-sm mb-2">{getTooltipContent()}</h3>
+          <ul>
+            {talks.map((talk, index) => (
+              <li key={index} className="text-sm text-gray-700">
+                {talk.title}
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : (
+        <p className="text-sm text-gray-500">Aucun talk prévu</p>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/Tooltip.ts
+++ b/src/hooks/Tooltip.ts
@@ -1,0 +1,28 @@
+import { useTooltipStore } from '@/stores/useTooltipStore';
+
+export function useTooltipLogic() {
+  const { talks, userRole } = useTooltipStore();
+
+  const getTooltipContent = () => {
+    if (userRole === 'public') {
+      if (talks.some((talk) => talk.isPastWithTalk)) return 'Talks auxquels vous avez participés';
+      if (talks.some((talk) => talk.isWithTalk || talk.isPublicTalk)) return 'Talk du jour';
+    }
+
+    if (userRole === 'speaker') {
+      if (talks.some((talk) => talk.isPastWithTalk)) return 'Talks auxquels vous avez participés';
+      if (talks.some((talk) => talk.isWithTalk)) return 'Talks du jour';
+      if (talks.some((talk) => talk.isSpeakerTalk)) return 'Vos interventions du jour';
+    }
+
+    if (userRole === 'organizer') {
+      if (talks.some((talk) => talk.isPastWithTalk)) return 'Talks passés';
+      if (talks.some((talk) => talk.isWithTalk)) return 'Talks validés';
+      if (talks.some((talk) => talk.isOrganizedTalk)) return 'Talks en attente de validation';
+    }
+
+    return 'Aucun titre disponible';
+  };
+
+  return { getTooltipContent };
+}

--- a/src/stores/useTooltipStore.ts
+++ b/src/stores/useTooltipStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+
+type Talk = {
+  title?: string;
+  isPastWithTalk?: boolean;
+  isWithTalk?: boolean;
+  isPublicTalk?: boolean;
+  isSpeakerTalk?: boolean;
+  isOrganizedTalk?: boolean;
+};
+
+type TooltipState = {
+  talks: Talk[];
+  position?: { top: number; left: number };
+  userRole: string;
+  setTooltipData: (talks: Talk[], position?: { top: number; left: number }, userRole?: string) => void;
+};
+
+export const useTooltipStore = create<TooltipState>((set) => ({
+  talks: [],
+  position: { top: 0, left: 0 },
+  userRole: 'public',
+  setTooltipData: (talks, position, userRole) =>
+    set((state) => ({
+      talks,
+      position: position ?? state.position,
+      userRole: userRole ?? state.userRole,
+    })),
+}));


### PR DESCRIPTION
Ajout du tooltip dans le calendrier:

- affiche un tooltip avec la liste des talks au survol des jours.
- le contenu du tooltip change selon le rôle utilisateur (public, speaker, organizer).
- utilisation d’un store Zustand pour gérer les talks et la position du tooltip.
- séparation de la logique métier dans un hook dédié.